### PR TITLE
Fix setter names in Panoramas model

### DIFF
--- a/Classes/Domain/Model/Panoramas.php
+++ b/Classes/Domain/Model/Panoramas.php
@@ -198,7 +198,7 @@ class Panoramas extends \TYPO3\CMS\Extbase\DomainObject\AbstractEntity
      *
      * @param string $uid
      */
-    public function SetUid($uid)
+    public function setUid($uid)
     {
         return $this->uid = $uid;
     }
@@ -217,7 +217,7 @@ class Panoramas extends \TYPO3\CMS\Extbase\DomainObject\AbstractEntity
      *
      * @param string $pid
      */
-    public function SetPid($pid)
+    public function setPid($pid)
     {
         return $this->pid = $pid;
     }


### PR DESCRIPTION
## Summary
- fix setter method names in `Panoramas`

## Testing
- `php -l Classes/Domain/Model/Panoramas.php`
- `php -l Classes/Controller/PanoramasController.php`
- `find . -name '*.php' | xargs -I {} php -l {}`

------
https://chatgpt.com/codex/tasks/task_e_6877539cc7508325baf05f872b18ea41