### PR TITLE
Refactor panorama form to Extbase object/property binding

### DIFF
--- a/Classes/Controller/PanoramasController.php
+++ b/Classes/Controller/PanoramasController.php
@@ -154,18 +154,13 @@ class PanoramasController extends \TYPO3\CMS\Extbase\Mvc\Controller\ActionContro
             $this->dataMapper = GeneralUtility::makeInstance(DataMapper::class);
         }
 
-        if ($this->request->hasArgument('panoramas')) {
-            if (!($this->persistenceManager instanceof PersistenceManager)) {
-                $this->persistenceManager = GeneralUtility::makeInstance(PersistenceManager::class);
-            }
-            $pano_array = $this->request->getArgument('panoramas');
-            $this->request->SetArgument('panoramas', $pano_array);
-            if ($pano_array['tp3businessviews'] > 0) {
-                $this->request->SetArgument('tp3businessview', ['uid'=>$pano_array['tp3businessviews']]);
-                // mm relations
-                if (!($this->tp3BusinessViewRepository instanceof Tp3BusinessViewRepository)) {
-                    $this->tp3BusinessViewRepository = GeneralUtility::makeInstance(Tp3BusinessViewRepository::class);
-                }
+        if (!($this->persistenceManager instanceof PersistenceManager)) {
+            $this->persistenceManager = GeneralUtility::makeInstance(PersistenceManager::class);
+        }
+        if ($this->request->hasArgument('tp3businessview')) {
+            // mm relations
+            if (!($this->tp3BusinessViewRepository instanceof Tp3BusinessViewRepository)) {
+                $this->tp3BusinessViewRepository = GeneralUtility::makeInstance(Tp3BusinessViewRepository::class);
             }
         }
         if ($this->cObj === null) {

--- a/Resources/Private/Partials/Tp3BusinessView/Finder.html
+++ b/Resources/Private/Partials/Tp3BusinessView/Finder.html
@@ -25,44 +25,44 @@ or search for the place on the map</div>
 
 </div><div id="businessview-panorama-canvas"></div></div>
 <div id="tp3businessview-floating-panel">
-    <f:form action="update" id="editform" controller="Panoramas"  name="update" object="{panorama}" arguments="{panorama: panorama}">
-    <f:form.hidden   name="panoramas[uid]" value="{panorama.uid}"  class="formvalue"  />
-    <f:form.hidden   name="panoramas[pid]" value="{panorama.pid}"  class="formvalue"  />
-        <f:form.select name="panoramas[tp3businessviews]"  multiple="false" options="{businessviews}" optionValueField="uid" optionLabelField="name" value="" errorClass="'f3-form-error'" class="form-control formvalue">
+    <f:form action="update" id="editform" controller="Panoramas" objectName="panoramas" object="{panorama}">
+    <f:form.hidden property="uid" class="formvalue" />
+    <f:form.hidden property="pid" class="formvalue" />
+        <f:form.select name="tp3businessview[uid]" multiple="false" options="{businessviews}" optionValueField="uid" optionLabelField="name" value="" errorClass="'f3-form-error'" class="form-control formvalue">
         </f:form.select>
         <table class="panoviewer">
         <tr>
             <td><b>Titel</b></td>
             <td class="title">
-               <f:form.textfield additionalAttributes="" required="true"  type="text" name="panoramas[title]"  value="{panorama.title}"  class="formvalue"  >
+               <f:form.textfield additionalAttributes="" required="true"  type="text" property="title"  class="formvalue"  >
             </f:form.textfield>
             </td>
         </tr><tr>
-            <td><b>Position</b></td><td ><f:form.textfield additionalAttributes="" name="panoramas[position]"  type="text" id="position-cell" value="{panorama.position-cell}"  class="formvalue"  >
+            <td><b>Position</b></td><td ><f:form.textfield additionalAttributes="" property="position" type="text" id="position-cell"  class="formvalue"  >
         </f:form.textfield>
             </td>
         </tr>
         <tr>
             <td><b>POV Heading</b></td><td >
-            <f:form.textfield additionalAttributes="" name="panoramas[heading]"  type="text" id="heading-cell" value="{panorama.heading-cell}"  class="formvalue"  >
+            <f:form.textfield additionalAttributes="" property="heading" type="text" id="heading-cell"  class="formvalue"  >
         </f:form.textfield>
         </td>
         </tr>
         <tr>
             <td><b>POV Pitch</b></td><td >
-            <f:form.textfield additionalAttributes="" name="panoramas[pitch]"  type="text" id="pitch-cell" value="{panorama.pitch-cell}"  class="formvalue"  >
+            <f:form.textfield additionalAttributes="" property="pitch" type="text" id="pitch-cell"  class="formvalue"  >
         </f:form.textfield>
         </td>
         </tr>
         <tr>
             <td><b>Pano ID</b></td><td >
-            <f:form.textfield additionalAttributes="" required="true" name="panoramas[panoId]"  type="text" id="pano-cell"  value="{panorama.panoId}"  class="formvalue"  >
+            <f:form.textfield additionalAttributes="" required="true" property="panoId" type="text" id="pano-cell"  class="formvalue"  >
         </f:form.textfield>
         </td>
         </tr>
         <tr>
             <td><b>Zoom</b></td><td >
-            <f:form.textfield additionalAttributes="" name="panoramas[zoom]"  type="text" id="zoom-cell"  value="{panorama.zoom}"  class="formvalue"  >
+            <f:form.textfield additionalAttributes="" property="zoom" type="text" id="zoom-cell"  class="formvalue"  >
             </f:form.textfield>
         </td>
         </tr>

--- a/Resources/Public/JavaScript/Tp3App.js
+++ b/Resources/Public/JavaScript/Tp3App.js
@@ -64,11 +64,11 @@ define(['jquery','https://maps.google.com/maps/api/js?key='+window.apikey+'&libr
 
 					var bwId=  $(this).attr("id").split("_");
 					if($.type(bwId) == "array" && bwId.length > 1){
-						$('select[name="tx_tp3businessview_web_tp3businessviewmodule[panoramas][tp3businessviews]"] option').prop('selected', false);
+						$('select[name="tx_tp3businessview_web_tp3businessviewmodule[tp3businessview][uid]"] option').prop('selected', false);
 						$('#businessview-canvas').find('[id="businessview-contact-canvas"]').remove();
 						$('#businessview-canvas').find('[id="businessview-externalLinks-canvas"]').remove();
 						//$('#editform').find('input[name="tx_tp3businessview_web_tp3businessviewmodule[panoramas][tp3businessviews]"]').val(bwId[1]);
-						$('select[name="tx_tp3businessview_web_tp3businessviewmodule[panoramas][tp3businessviews]"] option[value="' + bwId[1] + '"]').prop('selected', true);
+						$('select[name="tx_tp3businessview_web_tp3businessviewmodule[tp3businessview][uid]"] option[value="' + bwId[1] + '"]').prop('selected', true);
 						$('#editform').find('input[name="tx_tp3businessview_web_tp3businessviewmodule[panoramas][uid]"]').val($(this).next('.panolist.bwlist').find('.entry').first().attr("id").split("_")[1]);
 						$('#editform').find('input[name="tx_tp3businessview_web_tp3businessviewmodule[panoramas][pid]"]').val($(this).attr("id").split("_")[2]);
 
@@ -98,7 +98,7 @@ define(['jquery','https://maps.google.com/maps/api/js?key='+window.apikey+'&libr
 					console.log(e);
 					$('#editform').find('input[name="tx_tp3businessview_web_tp3businessviewmodule[panoramas][uid]"]').val($(this).attr("id").split("_")[1]);
 					$('#editform').find('input[name="tx_tp3businessview_web_tp3businessviewmodule[panoramas][pid]"]').val($(this).attr("id").split("_")[2]);
-					$('#editform').find('input[name="tx_tp3businessview_web_tp3businessviewmodule[panoramas][pano_id]"]').val($.trim($(this).find('.pano_id').val()));
+					$('#editform').find('input[name="tx_tp3businessview_web_tp3businessviewmodule[panoramas][panoId]"]').val($.trim($(this).find('.pano_id').val()));
 					$('#editform').find('input[name="tx_tp3businessview_web_tp3businessviewmodule[panoramas][heading]"]').val($.trim($(this).find('.heading').text()));
 					$('#editform').find('input[name="tx_tp3businessview_web_tp3businessviewmodule[panoramas][pitch]"]').val($.trim($(this).find('.pitch').text()));
 					$('#editform').find('input[name="tx_tp3businessview_web_tp3businessviewmodule[panoramas][position]"]').val($.trim($(this).find('.position').text()));


### PR DESCRIPTION
### Motivation
- Implement the previously proposed refactor so the panorama editor/finder uses Fluid/Extbase object/property binding instead of manually crafted nested field names.
- Align controller initialization and JavaScript field mappings with the Extbase form so property mapping and MM relation handling work reliably.

### Description
- Updated `Resources/Private/Partials/Tp3BusinessView/Finder.html` to use `<f:form ... objectName="panoramas" ...>` and `property="..."` attributes, replaced manual `panoramas[...]` hidden/inputs and switched the businessview selector to `tp3businessview[uid]`.
- Adjusted backend script `Resources/Public/JavaScript/Tp3App.js` to match the new form field names and mappings (notably `tp3businessview[uid]` and `panoramas[panoId]`).
- Simplified `Classes/Controller/PanoramasController.php::initializeAction()` by removing manual request-argument rewriting via `SetArgument(...)`, ensuring `PersistenceManager` is instantiated and `Tp3BusinessViewRepository` is initialized only when `tp3businessview` is present.

### Testing
- Ran `php -l Classes/Controller/PanoramasController.php` which returned no syntax errors and passed linting.
- No automated unit or functional tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dcc0e305448325b5ac450a4b05e206)