### PR TITLE
Add editor draft state, explicit save flow and status UI for BusinessView panoramas

### DIFF
--- a/Documentation/ToDoList/BusinessViewGuiProposal.md
+++ b/Documentation/ToDoList/BusinessViewGuiProposal.md
@@ -1,0 +1,108 @@
+# Vorschlag: bessere GUI für den BusinessView-Designer
+
+## Zielbild
+Die aktuelle Basis ist stark: `JsonResponseHandler` + `ModuleController` liefern schon die nötigen Daten/Endpoints.
+Im Frontend sollte die Oberfläche vom "Daten-Viewer" zu einem echten "Editor" weiterentwickelt werden – mit klarer Bearbeitungslogik, Live-Steuerung des Panoramas und sicherem Speichern.
+
+## Kernprobleme heute
+1. **Gemischte Oberfläche**: Liste, Viewer und Edit-Felder sind parallel sichtbar; es gibt keinen klaren Bearbeitungsmodus.
+2. **Unklare Save-Logik für Updates**: Für `update` wird eine Panorama-UID benötigt, im Formular ist das Feld aber nur versteckt vorhanden und im Flow nicht immer klar gesetzt.
+3. **Viewer statt Editor**: Der Pano-Viewer zeigt Daten und reagiert auf Interaktion, aber es fehlt ein geführter "Edit + Save" Workflow.
+4. **Wenig Feedback**: Nach Speichern/Fehlern gibt es vor allem `console.log`, aber keine stabile UX-Feedback-Fläche.
+
+## Empfohlene neue GUI-Struktur (3-Spalten-Editor)
+
+### 1) Linke Spalte – Datensatz-Navigation
+- Accordion/Liste aller BusinessViews.
+- Unter jedem BusinessView: zugehörige Panoramen als klickbare Einträge.
+- Aktionen pro Eintrag:
+  - "Neu Panorama"
+  - "Bearbeiten"
+  - "Duplizieren" (optional)
+  - "Löschen" (später)
+
+**Nutzen:** schnelle Navigation, klare Auswahl des aktiven Datensatzes.
+
+### 2) Mitte – Pano Stage (interaktiv)
+- Großer StreetView-Canvas als primäre Arbeitsfläche.
+- Kompakte Overlay-Controls:
+  - Links/Rechts drehen
+  - Pitch hoch/runter
+  - Zoom +/-
+  - Reset POV
+- Optionaler Modus-Schalter:
+  - "Map wählen" (Position aus Karte übernehmen)
+  - "Pano feinjustieren" (nur POV)
+
+**Nutzen:** Anwender arbeitet direkt im visuellen Kontext statt in Textfeldern.
+
+### 3) Rechte Spalte – Eigenschaften + Speichern
+- Formularfelder als strukturierte Sektionen:
+  - **Standort**: Position, Pano-ID
+  - **Kamera**: Heading, Pitch, Zoom
+  - **Metadaten**: Titel, Reihenfolge, Verknüpfung BusinessView
+- Sticky Action Bar unten:
+  - "Änderungen speichern"
+  - "Neu anlegen"
+  - "Verwerfen"
+- Statusindikator:
+  - "Nicht gespeichert" / "Gespeichert" / "Fehler"
+
+**Nutzen:** sichere Dateneingabe und klarer Commit-Punkt.
+
+## Interaktionsmodell (wichtig für Steuerbarkeit + Speichern)
+
+### A) Draft-State im Frontend
+- Ein zentrales `editorState`-Objekt halten:
+  - `selectedBusinessViewUid`
+  - `selectedPanoramaUid`
+  - `draft.position`, `draft.heading`, `draft.pitch`, `draft.zoom`, `draft.panoId`
+  - `isDirty`
+- Jede Panorama-Interaktion (`pov_changed`, `position_changed`, `zoom_changed`) schreibt in `editorState`.
+- UI-Felder werden aus `editorState` gerendert (nicht umgekehrt).
+
+### B) Explizite Save-Entscheidung
+- `selectedPanoramaUid > 0` => `update`
+- sonst => `create`
+- Vor Save clientseitig validieren:
+  - gültige Position
+  - numerische POV-Werte
+  - vorhandene BusinessView-Zuordnung
+
+### C) Optimistisches UX-Feedback
+- Während Save: Button disabled + Spinner.
+- Bei Erfolg: Toast "Gespeichert", `isDirty=false`, ggf. UID aktualisieren.
+- Bei Fehler: Fehlerbox mit Backend-Message (`message` aus JSON), keine stillen console-only Fehler.
+
+## Konkreter Umsetzungsplan in 3 Iterationen
+
+### Iteration 1 – UX-Basis
+1. Layout in 3 Spalten im Modul-Template.
+2. Ein "aktive Auswahl"-Modell einführen (BusinessView + Panorama).
+3. Sichtbares Feedbackpanel für Erfolg/Fehler.
+
+### Iteration 2 – Editor-State + Save-Fluss
+1. `editorState` in `Tp3App` ergänzen.
+2. `loadBusinessView(...)` beim Öffnen auch Panorama-UID/Felder sauber befüllen.
+3. `savePanorama()` kapseln (create/update Entscheidung intern).
+4. Dirty-State + Warnung bei Wechsel mit ungespeicherten Änderungen.
+
+### Iteration 3 – Bedienkomfort
+1. Keyboard-Shortcuts (z. B. Pfeile drehen, `Ctrl+S` speichern).
+2. Undo/Reset auf letzte gespeicherte Version.
+3. Mini-Preview der Panorama-Reihenfolge (drag & drop optional, später).
+
+## Warum das zu eurem Backend passt
+- `dispatchAction()` in `JsonResponseHandler` deckt `create/read/update` bereits ab.
+- Die Sortierlogik (`sortAction`) existiert und kann in der neuen linken Liste direkt weitergenutzt werden.
+- Das Backend muss dafür nicht grundlegend geändert werden; Schwerpunkt liegt auf einem robusten Frontend-State und einem klaren Save-Workflow.
+
+## Minimaler technischer Feinschliff (ohne Architekturbruch)
+1. Einheitliche Datenquelle: Felder immer aus `editorState` setzen.
+2. Bei "Bearbeiten" die `panoramas[uid]` zuverlässig setzen.
+3. Ein zentrales `renderEditorState()` statt verstreuter DOM-Schreibzugriffe.
+4. Standardisierte API-Fehlerbehandlung (HTTP + JSON `success`).
+
+## Fazit
+Kurz gesagt: **vom Viewer zum Editor**.
+Mit einem klaren 3-Spalten-Layout, zentralem Draft-State und explizitem Save-Flow wird das Pano zuverlässig steuerbar und das Ergebnis sicher speicherbar – ohne euer funktionierendes Backend neu zu bauen.

--- a/Resources/Private/Partials/Tp3BusinessView/Finder.html
+++ b/Resources/Private/Partials/Tp3BusinessView/Finder.html
@@ -91,13 +91,19 @@ or search for the place on the map</div>
 				>
 			</div>
 
-			<button type="submit" id="submitEditform" class="btn btn-primary">
-				Speichern
-			</button>
-			<button type="submit" id="submitNewform" class="btn btn-primary">
-				neu
-			</button>
-    </form>
-    <f:render partial="Tp3BusinessView/Controls" arguments="{settings:settings}" />
+				<button type="submit" id="submitEditform" class="btn btn-primary">
+					Speichern
+				</button>
+				<button type="submit" id="submitNewform" class="btn btn-primary">
+					neu
+				</button>
+				<button type="button" id="discardChanges" class="btn btn-default">
+					Verwerfen
+				</button>
+				<div id="tp3-editor-status" class="alert alert-secondary mt-2 mb-0" role="status">
+					Bereit
+				</div>
+	    </form>
+	    <f:render partial="Tp3BusinessView/Controls" arguments="{settings:settings}" />
 
-</div>
+	</div>

--- a/Resources/Private/Partials/Tp3BusinessView/Panorama.html
+++ b/Resources/Private/Partials/Tp3BusinessView/Panorama.html
@@ -16,10 +16,21 @@
 			</f:if>
 		</td>
 
-		<td class="">
-			<button class="btn btn-secondary actions-view pano" type="button" data-bv-uid="{panorama.uid}" data-view-type="pano">
-				{core:icon(identifier:'actions-view')}
-			</button>
+			<td class="">
+				<button
+					class="btn btn-secondary actions-view pano"
+					type="button"
+					data-bv-uid="{panorama.uid}"
+					data-view-type="pano"
+					data-pano-uid="{panorama.uid}"
+					data-pano-heading="{panorama.heading}"
+					data-pano-pitch="{panorama.pitch}"
+					data-pano-zoom="{panorama.zoom}"
+					data-pano-position="{panorama.position}"
+					data-pano-id="{panorama.panoId}"
+				>
+					{core:icon(identifier:'actions-view')}
+				</button>
 
 			<input type="hidden" name="panoramas[pano_id]" value="{panorama.pano_id}" class="formvalue pano_id" />
 			<f:format.crop maxCharacters="10">{panorama.pano_id}{panorama.panoId}</f:format.crop>

--- a/Resources/Public/Css/Backend/Tp3Backend.css
+++ b/Resources/Public/Css/Backend/Tp3Backend.css
@@ -198,6 +198,16 @@ div.bwentry {
     border: 0px solid #999;
 }
 
+#tp3businessview-floating-panel .btn {
+    margin-right: 6px;
+    margin-top: 6px;
+}
+
+#tp3-editor-status {
+    line-height: 1.4;
+    font-size: 12px;
+}
+
 .panoviewer {
 
     width: 100%;

--- a/Resources/Public/JavaScript/Tp3App.js
+++ b/Resources/Public/JavaScript/Tp3App.js
@@ -107,10 +107,105 @@ const Tp3App = {
 		}
 	},
 
+	parsePosition(positionValue) {
+		if (!positionValue) {
+			return null;
+		}
+
+		if (typeof positionValue === 'object' && typeof positionValue.lat === 'number' && typeof positionValue.lng === 'number') {
+			return positionValue;
+		}
+
+		const normalized = String(positionValue).replace(/[()]/g, '');
+		const chunks = normalized.split(',');
+		if (chunks.length !== 2) {
+			return null;
+		}
+
+		const lat = parseFloat(chunks[0]);
+		const lng = parseFloat(chunks[1]);
+
+		if (Number.isNaN(lat) || Number.isNaN(lng)) {
+			return null;
+		}
+
+		return { lat, lng };
+	},
+
+	updateStatus(message, level = 'secondary') {
+		const statusNode = document.getElementById('tp3-editor-status');
+		if (!statusNode) {
+			return;
+		}
+
+		statusNode.className = `alert alert-${level} mt-2 mb-0`;
+		statusNode.textContent = message;
+	},
+
+	serializeCurrentPosition() {
+		if (!this.BusinessAdress) {
+			return '';
+		}
+
+		if (typeof this.BusinessAdress.toString === 'function' && typeof this.BusinessAdress.lat === 'function') {
+			return this.BusinessAdress.toString();
+		}
+
+		const lat = typeof this.BusinessAdress.lat === 'function' ? this.BusinessAdress.lat() : this.BusinessAdress.lat;
+		const lng = typeof this.BusinessAdress.lng === 'function' ? this.BusinessAdress.lng() : this.BusinessAdress.lng;
+
+		if (typeof lat === 'number' && typeof lng === 'number') {
+			return `(${lat}, ${lng})`;
+		}
+
+		return '';
+	},
+
+	updateDraft(patch = {}, markDirty = true) {
+		this.editorState.draft = Object.assign({}, this.editorState.draft, patch);
+		if (markDirty) {
+			this.editorState.isDirty = true;
+		}
+		this.renderEditorState();
+	},
+
+	renderEditorState() {
+		const draft = this.editorState.draft || {};
+		const uidField = document.querySelector('input[name="panoramas[uid]"]');
+		const headingCell = document.getElementById('heading-cell');
+		const pitchCell = document.getElementById('pitch-cell');
+		const zoomCell = document.getElementById('zoom-cell');
+		const positionCell = document.getElementById('position-cell');
+		const panoCell = document.getElementById('pano-cell');
+
+		if (uidField) {
+			uidField.value = this.editorState.selectedPanoramaUid ? String(this.editorState.selectedPanoramaUid) : '';
+		}
+		if (headingCell) headingCell.value = draft.heading ?? '';
+		if (pitchCell) pitchCell.value = draft.pitch ?? '';
+		if (zoomCell) zoomCell.value = draft.zoom ?? '';
+		if (positionCell) positionCell.value = draft.position ?? '';
+		if (panoCell) panoCell.value = draft.panoId ?? '';
+	},
+
+	resetDraftFromCurrentView() {
+		this.editorState.draft = {
+			heading: this.pov.heading ?? 0,
+			pitch: this.pov.pitch ?? 0,
+			zoom: this.pov.zoom ?? 1,
+			position: this.serializeCurrentPosition(),
+			panoId: this.panorama ? (this.panorama.getPano() || '') : '',
+		};
+		this.editorState.isDirty = false;
+		this.renderEditorState();
+	},
+
 	applyHandlers() {
 		const form = document.querySelector('#editform');
 		const submitEditform = document.querySelector('#submitEditform');
 		const submitNewform = document.querySelector('#submitNewform');
+		const discardChanges = document.querySelector('#discardChanges');
+		const businessViewSelect = form ? form.querySelector('select[name="tp3businessview[uid]"]') : null;
 
 		if (!form) {
 			return;
@@ -122,12 +217,16 @@ const Tp3App = {
 		this._businessViewClickHandlerBound = true;
 
 		const getSelectedBusinessViewUid = () => {
-			const businessViewSelect = form.querySelector('select[name="tp3businessview[uid]"]');
 			if (!businessViewSelect) {
 				return 0;
 			}
 
 			return parseInt(businessViewSelect.value, 10) || 0;
+		};
+
+		const setSelectedPanoramaUid = (uid) => {
+			this.editorState.selectedPanoramaUid = parseInt(uid, 10) || 0;
+			this.renderEditorState();
 		};
 
 		const sendForm = async (submitType) => {
@@ -137,11 +236,36 @@ const Tp3App = {
 			const businessViewUid = getSelectedBusinessViewUid();
 			if (businessViewUid > 0) {
 				formData.set('tp3businessview[uid]', String(businessViewUid));
+				this.editorState.selectedBusinessViewUid = businessViewUid;
 			} else {
 				formData.delete('tp3businessview[uid]');
 			}
 
+			const panoramaUid = this.editorState.selectedPanoramaUid || parseInt(formData.get('panoramas[uid]') || '0', 10);
+			if (submitType === 'update' && panoramaUid <= 0) {
+				this.updateStatus('Bitte zuerst ein Panorama auswählen.', 'warning');
+				return;
+			}
+			if (panoramaUid > 0) {
+				formData.set('panoramas[uid]', String(panoramaUid));
+			}
+
+			const headingValue = formData.get('tx_tp3businessview_module[panorama][heading]');
+			const pitchValue = formData.get('tx_tp3businessview_module[panorama][pitch]');
+			const zoomValue = formData.get('tx_tp3businessview_module[panorama][zoom]');
+			if (
+				Number.isNaN(parseFloat(String(headingValue ?? ''))) ||
+				Number.isNaN(parseFloat(String(pitchValue ?? ''))) ||
+				Number.isNaN(parseFloat(String(zoomValue ?? '')))
+			) {
+				this.updateStatus('Heading/Pitch/Zoom müssen numerisch sein.', 'warning');
+				return;
+			}
+
 			try {
+				this.updateStatus('Speichern läuft …', 'info');
+				if (submitEditform) submitEditform.disabled = true;
+				if (submitNewform) submitNewform.disabled = true;
 				const response = await fetch(form.action, {
 					method: 'POST',
 					credentials: 'same-origin',
@@ -157,12 +281,26 @@ const Tp3App = {
 				}
 
 				const data = await response.json();
+				if (!data || data.success !== true) {
+					throw new Error(data && data.message ? data.message : 'Unbekannter API-Fehler');
+				}
+
+				if (data.uid) {
+					setSelectedPanoramaUid(data.uid);
+				}
+
+				this.editorState.isDirty = false;
+				this.updateStatus('Gespeichert.', 'success');
 				console.log('Antwort vom Endpunkt:', data);
 			} catch (error) {
+				this.updateStatus(`Senden fehlgeschlagen: ${error.message}`, 'danger');
 				console.error('Senden an den Endpunkt fehlgeschlagen:', error);
+			} finally {
+				if (submitEditform) submitEditform.disabled = false;
+				if (submitNewform) submitNewform.disabled = false;
 			}
 		};
-		const loadBusinessView = async (uid , type) => {
+		const loadBusinessView = async (uid, type) => {
 			if (!form) {
 				return;
 			}
@@ -183,8 +321,39 @@ const Tp3App = {
 
 				const data = await response.json();
 				Tp3App.businessview_initialize(data);
+
+				if (type === 'pano' && data && data.businessview && data.businessview[0]) {
+					const record = data.businessview[0];
+					const heading = parseFloat(record.heading ?? '0') || 0;
+					const pitch = parseFloat(record.pitch ?? '0') || 0;
+					const zoom = parseFloat(record.zoom ?? '1') || 1;
+					const position = record.position || '';
+					const parsedPosition = this.parsePosition(position);
+					const panoId = record.panoId || record.pano_id || '';
+
+					this.pov = { heading, pitch, zoom };
+					if (parsedPosition) {
+						this.BusinessAdress = parsedPosition;
+					}
+
+					setSelectedPanoramaUid(record.uid || uid);
+					this.updateDraft({
+						heading,
+						pitch,
+						zoom,
+						position,
+						panoId,
+					}, false);
+					this.editorState.isDirty = false;
+				} else {
+					setSelectedPanoramaUid(0);
+					this.resetDraftFromCurrentView();
+				}
+
 				Tp3App.initPano(data);
+				this.updateStatus(type === 'pano' ? 'Panorama geladen.' : 'BusinessView geladen.', 'secondary');
 			} catch (error) {
+				this.updateStatus(`Laden fehlgeschlagen: ${error.message}`, 'danger');
 				console.error('Businessview laden fehlgeschlagen:', error);
 			}
 		};
@@ -219,15 +388,17 @@ const Tp3App = {
 					throw new Error(`HTTP ${response.status}`);
 				}
 
-				const data = await response.json();
-				console.log('Sortierung gespeichert:', data);
+					const data = await response.json();
+					console.log('Sortierung gespeichert:', data);
+					this.updateStatus('Sortierung gespeichert.', 'success');
 
-				// optional: Tabelle neu laden / DOM aktualisieren
-				window.location.reload();
-			} catch (error) {
-				console.error('Sortierung fehlgeschlagen:', error);
-			}
-		};
+					// optional: Tabelle neu laden / DOM aktualisieren
+					window.location.reload();
+				} catch (error) {
+					this.updateStatus(`Sortierung fehlgeschlagen: ${error.message}`, 'danger');
+					console.error('Sortierung fehlgeschlagen:', error);
+				}
+			};
 
 		if (submitEditform) {
 			submitEditform.addEventListener('click', (event) => {
@@ -236,16 +407,56 @@ const Tp3App = {
 			});
 		}
 
-		if (submitNewform) {
-			submitNewform.addEventListener('click', (event) => {
-				event.preventDefault();
-				sendForm('create');
-			});
-		}
+			if (submitNewform) {
+				submitNewform.addEventListener('click', (event) => {
+					event.preventDefault();
+					sendForm('create');
+				});
+			}
 
-		document.addEventListener('click', function (event) {
-			const button = event.target.closest('.actions-view');
-			if (!button) return;
+			if (discardChanges) {
+				discardChanges.addEventListener('click', () => {
+					this.resetDraftFromCurrentView();
+					this.updateStatus('Änderungen verworfen.', 'secondary');
+				});
+			}
+
+			if (businessViewSelect) {
+				this.editorState.selectedBusinessViewUid = getSelectedBusinessViewUid();
+				businessViewSelect.addEventListener('change', () => {
+					if (this.editorState.isDirty && !window.confirm('Ungespeicherte Änderungen verwerfen?')) {
+						businessViewSelect.value = String(this.editorState.selectedBusinessViewUid || 0);
+						return;
+					}
+
+					this.editorState.selectedBusinessViewUid = getSelectedBusinessViewUid();
+					this.editorState.selectedPanoramaUid = 0;
+					this.resetDraftFromCurrentView();
+					this.updateStatus('BusinessView gewechselt.', 'secondary');
+				});
+			}
+
+			['heading-cell', 'pitch-cell', 'zoom-cell', 'position-cell', 'pano-cell'].forEach((fieldId) => {
+				const field = document.getElementById(fieldId);
+				if (!field) {
+					return;
+				}
+
+				field.addEventListener('input', () => {
+					const patch = {};
+					if (fieldId === 'heading-cell') patch.heading = field.value;
+					if (fieldId === 'pitch-cell') patch.pitch = field.value;
+					if (fieldId === 'zoom-cell') patch.zoom = field.value;
+					if (fieldId === 'position-cell') patch.position = field.value;
+					if (fieldId === 'pano-cell') patch.panoId = field.value;
+					this.updateDraft(patch, true);
+					this.updateStatus('Ungespeicherte Änderungen.', 'warning');
+				});
+			});
+
+			document.addEventListener('click', function (event) {
+				const button = event.target.closest('.actions-view');
+				if (!button) return;
 
 			const type = button.getAttribute('data-view-type');
 			const uid = button.getAttribute('data-bv-uid');
@@ -254,14 +465,25 @@ const Tp3App = {
 			loadBusinessView(uid, type);
 		});
 
-		document.addEventListener('click', function (event) {
-			const button = event.target.closest('.pano-sort');
-			if (!button) return;
+			document.addEventListener('click', function (event) {
+				const button = event.target.closest('.pano-sort');
+				if (!button) return;
 
-			event.preventDefault();
-			sortPanorama(button);
-		});
-	},
+				event.preventDefault();
+				sortPanorama(button);
+			});
+
+			window.addEventListener('beforeunload', (event) => {
+				if (!this.editorState.isDirty) {
+					return;
+				}
+				event.preventDefault();
+				event.returnValue = '';
+			});
+
+			this.resetDraftFromCurrentView();
+			this.updateStatus('Editor bereit.', 'secondary');
+		},
 
 
 	bindPanoramaState(panoCanvas, panorama) {
@@ -429,6 +651,9 @@ const Tp3App = {
 			}
 
 			this.BusinessAdress = pano.getPosition();
+			this.updateDraft({
+				position: pano.getPosition() + '',
+			});
 		});
 
 		pano.addListener('pov_changed', () => {
@@ -443,6 +668,11 @@ const Tp3App = {
 				pitch: pov.pitch,
 				zoom: pano.getZoom(),
 			};
+			this.updateDraft({
+				heading: pov.heading,
+				pitch: pov.pitch,
+				zoom: pano.getZoom(),
+			});
 
 			if (headingCell) headingCell.value = pov.heading;
 			if (pitchCell) pitchCell.value = pov.pitch;
@@ -453,6 +683,9 @@ const Tp3App = {
 		if (panoCell) {
 			panoCell.value = data.location.pano || '';
 		}
+		this.updateDraft({
+			panoId: data.location.pano || '',
+		});
 
 		const positionCell = document.getElementById('position-cell');
 		if (positionCell) {
@@ -469,6 +702,7 @@ const Tp3App = {
 		if (zoomCell) zoomCell.value = pano.getZoom();
 
 		this.panorama = pano;
+		this.editorState.isDirty = false;
 	},
 
 	loadPanoramaForPlace(place) {
@@ -616,8 +850,20 @@ const Tp3App = {
 		panoJumpsRandom: true,
 	},
 
-	geocoder: null,
-	infowindow: null,
+		geocoder: null,
+		infowindow: null,
+		editorState: {
+			selectedBusinessViewUid: 0,
+			selectedPanoramaUid: 0,
+			draft: {
+				heading: 270,
+				pitch: 0,
+				zoom: 1,
+				position: '',
+				panoId: '',
+			},
+			isDirty: false,
+		},
 };
 
 window.Tp3App = Tp3App;


### PR DESCRIPTION
### Motivation
- Move the current Pano UI from a passive viewer to a guided editor with an explicit draft/save workflow to avoid lost or ambiguous updates.
- Fix brittle update/create semantics where panorama UID and form fields were hidden or not reliably set during saves.
- Improve UX feedback so save/load/sort errors and statuses are visible instead of only logged to the console.

### Description
- Add a new proposal document `Documentation/ToDoList/BusinessViewGuiProposal.md` describing a 3-column editor, draft model and iterative plan.\
- Extend the Finder partial `Resources/Private/Partials/Tp3BusinessView/Finder.html` with a `Verwerfen` button and a `#tp3-editor-status` status panel.\
- Enhance the Panorama partial `Resources/Private/Partials/Tp3BusinessView/Panorama.html` to include detailed `data-` attributes on panorama action buttons so the frontend can seed the editor draft.\
- Update CSS `Resources/Public/Css/Backend/Tp3Backend.css` to style the new buttons and status area.\
- Major JS changes in `Resources/Public/JavaScript/Tp3App.js`: introduce `editorState` with `draft` and `isDirty`, add helpers `parsePosition`, `serializeCurrentPosition`, `updateStatus`, `updateDraft`, `renderEditorState` and `resetDraftFromCurrentView`, wire explicit create/update save logic with client-side validation, wire draft updates from StreetView events (`pov_changed`, `position_changed`), add discard behavior, change-business-view guard for dirty state, beforeunload prompt, and status messages for load/save/sort flows.

### Testing
- No automated test suite exists for this backend/frontend module so no CI unit tests were executed.\
- The changes were limited to DOM/UI, CSS and client-side logic; no automated tests were added as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0157756a88325ac2be600921c64d0)