### PR TITLE
Reuse StreetViewPanorama, enable motion tracking, and avoid duplicate listeners

### DIFF
--- a/Resources/Public/JavaScript/Tp3App.js
+++ b/Resources/Public/JavaScript/Tp3App.js
@@ -634,50 +634,66 @@ const Tp3App = {
 			return;
 		}
 
-		panoCanvas.innerHTML = '';
-
-		const pano = new google.maps.StreetViewPanorama(panoCanvas, {
+		const panoramaOptions = {
 			position: data.location.latLng,
 			pano: data.location.pano,
 			pov: this.pov,
 			zoom: this.pov.zoom,
 			visible: true,
-		});
+			motionTracking: true,
+			motionTrackingControl: true,
+		};
+		const pano = this.panorama || new google.maps.StreetViewPanorama(panoCanvas, panoramaOptions);
 
-		pano.addListener('position_changed', () => {
-			const positionCell = document.getElementById('position-cell');
-			if (positionCell) {
-				positionCell.value = pano.getPosition() + '';
-			}
-
-			this.BusinessAdress = pano.getPosition();
-			this.updateDraft({
-				position: pano.getPosition() + '',
+		if (this.panorama) {
+			pano.setOptions({
+				pov: this.pov,
+				zoom: this.pov.zoom,
+				visible: true,
+				motionTracking: true,
+				motionTrackingControl: true,
 			});
-		});
+			pano.setPosition(data.location.latLng);
+			pano.setPano(data.location.pano);
+		}
 
-		pano.addListener('pov_changed', () => {
-			const headingCell = document.getElementById('heading-cell');
-			const pitchCell = document.getElementById('pitch-cell');
-			const zoomCell = document.getElementById('zoom-cell');
+		if (!this._panoramaPanelEventsBound) {
+			pano.addListener('position_changed', () => {
+				const positionCell = document.getElementById('position-cell');
+				if (positionCell) {
+					positionCell.value = pano.getPosition() + '';
+				}
 
-			const pov = pano.getPov();
-
-			this.pov = {
-				heading: pov.heading,
-				pitch: pov.pitch,
-				zoom: pano.getZoom(),
-			};
-			this.updateDraft({
-				heading: pov.heading,
-				pitch: pov.pitch,
-				zoom: pano.getZoom(),
+				this.BusinessAdress = pano.getPosition();
+				this.updateDraft({
+					position: pano.getPosition() + '',
+				});
 			});
 
-			if (headingCell) headingCell.value = pov.heading;
-			if (pitchCell) pitchCell.value = pov.pitch;
-			if (zoomCell) zoomCell.value = pano.getZoom();
-		});
+			pano.addListener('pov_changed', () => {
+				const headingCell = document.getElementById('heading-cell');
+				const pitchCell = document.getElementById('pitch-cell');
+				const zoomCell = document.getElementById('zoom-cell');
+
+				const pov = pano.getPov();
+
+				this.pov = {
+					heading: pov.heading,
+					pitch: pov.pitch,
+					zoom: pano.getZoom(),
+				};
+				this.updateDraft({
+					heading: pov.heading,
+					pitch: pov.pitch,
+					zoom: pano.getZoom(),
+				});
+
+				if (headingCell) headingCell.value = pov.heading;
+				if (pitchCell) pitchCell.value = pov.pitch;
+				if (zoomCell) zoomCell.value = pano.getZoom();
+			});
+			this._panoramaPanelEventsBound = true;
+		}
 
 		const panoCell = document.getElementById('pano-cell');
 		if (panoCell) {
@@ -702,6 +718,10 @@ const Tp3App = {
 		if (zoomCell) zoomCell.value = pano.getZoom();
 
 		this.panorama = pano;
+		if (!this._panoramaEventsBound) {
+			this.bindPanoramaEvents();
+			this._panoramaEventsBound = true;
+		}
 		this.editorState.isDirty = false;
 	},
 


### PR DESCRIPTION
### Motivation
- Enable device motion tracking support in the Street View viewer so mobile device orientation can drive the panorama (`motionTracking` / `motionTrackingControl`).
- Improve UX and performance by avoiding re-creating the panorama viewer on every place change and instead updating an existing instance to prevent flicker.
- Prevent duplicate event handling after multiple place changes by ensuring listeners are bound only once.

### Description
- Reworked `loadPanoramaFromStreetViewResult` in `Resources/Public/JavaScript/Tp3App.js` to reuse `this.panorama` when present instead of always creating a new `google.maps.StreetViewPanorama` instance. 
- Added `motionTracking: true` and `motionTrackingControl: true` to panorama options and applied them via `setOptions` when reusing the panorama. 
- Guarded panorama panel listeners with `_panoramaPanelEventsBound` and panorama-wide listeners with `_panoramaEventsBound` and call `bindPanoramaEvents()` only once to avoid duplicate bindings. 
- Kept existing draft/UI sync logic (`updateDraft`, filling `position/pano/heading/pitch/zoom` cells) and ensured `this.panorama` is updated to the active panorama object.

### Testing
- Ran `node --check Resources/Public/JavaScript/Tp3App.js` which completed without syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e091840d308325959e92b1644abf74)