### PR TITLE
Sync panorama state back to editor form on pano jumps and repositioning

### DIFF
--- a/Resources/Public/JavaScript/BusinessViewRenderer.js
+++ b/Resources/Public/JavaScript/BusinessViewRenderer.js
@@ -115,6 +115,9 @@ export function initBusinessViewRenderer({ $, Tp3App, window, document }) {
 			scrollwheel: true
 		});
 		Tp3App.panorama = panorama;
+		if (typeof Tp3App.bindPanoramaEvents === 'function') {
+			Tp3App.bindPanoramaEvents();
+		}
 	};
 	Tp3App.toggleBusinessViewFullscreen = function () {
 		const businessviewCanvas = document.getElementById('businessview-canvas');

--- a/Resources/Public/JavaScript/Tp3App.js
+++ b/Resources/Public/JavaScript/Tp3App.js
@@ -783,7 +783,7 @@ const Tp3App = {
 		});
 	},
 
-	syncPanoramaPanel(pano) {
+	syncPanoramaPanel(pano, markDirty = true) {
 		const positionCell = document.getElementById('position-cell');
 		const headingCell = document.getElementById('heading-cell');
 		const pitchCell = document.getElementById('pitch-cell');
@@ -796,26 +796,46 @@ const Tp3App = {
 
 		const position = pano.getPosition();
 		const pov = pano.getPov();
+		const patch = {
+			panoId: pano.getPano() || '',
+		};
 
 		if (positionCell && position) {
 			positionCell.value = position.toString();
+			patch.position = position.toString();
 		}
 
 		if (headingCell && pov) {
 			headingCell.value = pov.heading;
+			patch.heading = pov.heading;
 		}
 
 		if (pitchCell && pov) {
 			pitchCell.value = pov.pitch;
+			patch.pitch = pov.pitch;
 		}
 
 		if (zoomCell) {
 			zoomCell.value = pano.getZoom();
+			patch.zoom = pano.getZoom();
 		}
 
 		if (panoCell) {
-			panoCell.value = pano.getPano() || '';
+			panoCell.value = patch.panoId;
 		}
+
+		if (position) {
+			this.BusinessAdress = position;
+		}
+		if (pov) {
+			this.pov = {
+				heading: pov.heading,
+				pitch: pov.pitch,
+				zoom: pano.getZoom(),
+			};
+		}
+
+		this.updateDraft(patch, markDirty);
 	},
 
 
@@ -838,6 +858,12 @@ const Tp3App = {
 		this.panorama.addListener('zoom_changed', () => {
 			this.syncPanoramaPanel(this.panorama);
 		});
+
+		this.panorama.addListener('pano_changed', () => {
+			this.syncPanoramaPanel(this.panorama);
+		});
+
+		this.syncPanoramaPanel(this.panorama, false);
 	},
 
 	BusinessAdress: { lat: 49.9553939, lng: 8.1767639 },


### PR DESCRIPTION
### Motivation
- Ensure the floating editor form reflects the live Street View panorama state so that repositioning or pano-to-pano jumps update the form and the internal draft state. 
- Make tour jumps and user interactions produce consistent values for heading, pitch, zoom, position and pano id in the editor so saves and subsequent navigation behave predictably.

### Description
- Updated `Resources/Public/JavaScript/Tp3App.js` to extend `syncPanoramaPanel` to collect `heading`, `pitch`, `zoom`, `position` and `panoId` into a `patch` and call `updateDraft(patch, markDirty)` so the editor draft mirrors the panorama state. 
- Made `syncPanoramaPanel` accept an optional `markDirty` parameter and used it to perform an initial non-dirty sync when binding events. 
- Added listeners for `pano_changed` in `bindPanoramaEvents` so pano-to-pano jumps propagate into the form, and trigger an initial `syncPanoramaPanel(..., false)` when events are attached. 
- Updated `Resources/Public/JavaScript/BusinessViewRenderer.js` to call `Tp3App.bindPanoramaEvents()` immediately after creating the `StreetViewPanorama` to ensure events are wired right away. 
- Files changed: `Resources/Public/JavaScript/Tp3App.js`, `Resources/Public/JavaScript/BusinessViewRenderer.js`.

### Testing
- Ran `node --check Resources/Public/JavaScript/Tp3App.js` and it succeeded. 
- Ran `node --check Resources/Public/JavaScript/BusinessViewRenderer.js` and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e09690261c832583c0999242de24ee)