### PR TITLE
Initialize frontend with selected BusinessView JSON and load assets for Google Maps integration

### DIFF
--- a/Classes/Controller/Tp3BusinessViewController.php
+++ b/Classes/Controller/Tp3BusinessViewController.php
@@ -141,23 +141,32 @@ class Tp3BusinessViewController extends ActionController
 
     public function listAction(): ResponseInterface
     {
-        $context = GeneralUtility::makeInstance(Context::class);
-        if(is_int($this->settings["businessview"] )){
-            $businessview = $this->tp3BusinessViewRepository->findByUid($this->settings["businessview"])->getFirst();
-            $panorama = $this->panoramasRepository->findAll();
-            $address = $this->businessAdressRepository->findAll();
+        $selectedBusinessViewUid = (int)($this->settings['businessview'] ?? 0);
+        $selectedBusinessView = null;
+        $businessview = null;
+        $panorama = $this->panoramasRepository->findAll();
+        $address = $this->businessAdressRepository->findAll();
+
+        if ($selectedBusinessViewUid > 0) {
+            $selectedBusinessView = $this->tp3BusinessViewRepository->findByUid($selectedBusinessViewUid);
+            $businessview = $selectedBusinessView;
         }
-        else{
+
+        if ($businessview === null) {
             $businessview = $this->tp3BusinessViewRepository->findAll();
-            $panorama = $this->panoramasRepository->findAll();
-            $address = $this->businessAdressRepository->findAll();
         }
+
+        $this->pageRenderer->loadJavaScriptModule('@tp3/tp3-businessview/Tp3Bootstrap.js');
+        $this->pageRenderer->addCssFile('EXT:tp3_businessview/Resources/Public/Css/Tp3App.css');
 
         $this->view->assignMultiple(
             [
                 'businessview' => $businessview,
                 'panorama' => $panorama,
-                'address' => $address
+                'address' => $address,
+                'googleMapsJavaScriptApiKey' => $this->extensionConfiguration->getGoogleMapsJavaScriptApiKey(),
+                'selectedBusinessViewUid' => $selectedBusinessViewUid,
+                'selectedBusinessView' => $selectedBusinessView,
             ]
         );
         return $this->htmlResponse($this->view->render());

--- a/Resources/Private/Templates/Tp3BusinessView/List.html
+++ b/Resources/Private/Templates/Tp3BusinessView/List.html
@@ -2,7 +2,52 @@
 <f:layout name="Default" />
 
 <f:section name="main">
+    <div
+        id="tp3-businessview-app"
+        data-api-key="{googleMapsJavaScriptApiKey}"
+    ></div>
 
-    <div id="tp3businessview-businessview-canvas" class="businessview"></div>
+    <div id="businessview-canvas" class="businessview">
+        <div id="businessview-panorama-canvas"></div>
+    </div>
+
+    <table class="panolist" style="display:none;">
+        <f:if condition="{selectedBusinessViewUid} > 0">
+            <f:then>
+                <f:for each="{businessview.panoramas}" as="panorama">
+                    <f:render partial="Tp3BusinessView/Panorama" arguments="{panorama: panorama, settings: settings, businessview: businessview}" />
+                </f:for>
+            </f:then>
+            <f:else>
+                <f:for each="{businessview}" as="businessviewItem">
+                    <f:for each="{businessviewItem.panoramas}" as="panorama">
+                        <f:render partial="Tp3BusinessView/Panorama" arguments="{panorama: panorama, settings: settings, businessview: businessviewItem}" />
+                    </f:for>
+                </f:for>
+            </f:else>
+        </f:if>
+    </table>
+
+    <f:if condition="{selectedBusinessView}">
+        <f:asset.script identifier="tp3-businessview-fe-json">
+            window.businessviewJson = {
+                businessview: [{
+                    uid: {selectedBusinessView.uid},
+                    intro: <f:format.json value="{selectedBusinessView.intro}" />,
+                    description: <f:format.json value="{selectedBusinessView.description}" />,
+                    contact: {
+                        name: <f:format.json value="{selectedBusinessView.contact.name}" />,
+                        address: <f:format.json value="{selectedBusinessView.contact.address}" />,
+                        zip: <f:format.json value="{selectedBusinessView.contact.zip}" />,
+                        city: <f:format.json value="{selectedBusinessView.contact.city}" />,
+                        phone: <f:format.json value="{selectedBusinessView.contact.phone}" />,
+                        mobile: <f:format.json value="{selectedBusinessView.contact.mobile}" />,
+                        email: <f:format.json value="{selectedBusinessView.contact.email}" />,
+                        website: <f:format.json value="{selectedBusinessView.contact.www}" />
+                    }
+                }]
+            };
+        </f:asset.script>
+    </f:if>
 </f:section>
 </html>

--- a/Resources/Public/JavaScript/Tp3App.js
+++ b/Resources/Public/JavaScript/Tp3App.js
@@ -99,6 +99,10 @@ const Tp3App = {
 		this.setAnimationOptions();
 		this.initPano();
 		this.initMap();
+
+		if (window.businessviewJson && typeof this.businessview_initialize === 'function') {
+			this.businessview_initialize(window.businessviewJson);
+		}
 	},
 
 	syncBusinessLocation(location, panoData) {


### PR DESCRIPTION
### Motivation
- Allow the frontend plugin to target a single `BusinessView` when configured and provide its data to the client as structured JSON. 
- Ensure the frontend gets the Google Maps JavaScript API key and required assets so the viewer can initialize without relying on server-side list parsing. 
- Improve client initialization by invoking a dedicated bootstrap entry when the server provides `businessview` data. 

### Description
- Updated `listAction` in `Tp3BusinessViewController` to treat `settings['businessview']` as an integer, load a single `BusinessView` when a UID is provided, and fall back to `findAll()` otherwise. 
- Added view assignments for `googleMapsJavaScriptApiKey`, `selectedBusinessViewUid`, and `selectedBusinessView`, and loaded frontend assets with `pageRenderer->loadJavaScriptModule('@tp3/tp3-businessview/Tp3Bootstrap.js')` and `pageRenderer->addCssFile('EXT:tp3_businessview/Resources/Public/Css/Tp3App.css')`. 
- Modified `Resources/Private/Templates/Tp3BusinessView/List.html` to add a root app element with `data-api-key`, reorganize panorama/canvas markup, render the panorama list conditionally based on `selectedBusinessViewUid`, and inject a `window.businessviewJson` payload when a single `BusinessView` is selected. 
- Changed `Resources/Public/JavaScript/Tp3App.js` to call `this.businessview_initialize(window.businessviewJson)` after initialization when `window.businessviewJson` is present. 

### Testing
- No new automated tests were added for these changes. 
- Executed the existing automated test suite and linters against the modified files and they completed without failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0e3c68ef48325855f93f3dd8e54e9)