### PR TITLE
Honor panoAnimation toggles and preserve jump/rotation settings across pano switches

### DIFF
--- a/Resources/Public/JavaScript/Tp3App.js
+++ b/Resources/Public/JavaScript/Tp3App.js
@@ -379,6 +379,25 @@ const Tp3App = {
 				this.AnmationOptions.panoJumpsRandom = String(settings.panoJumpsRandom) === '1';
 			}
 		};
+		const toAnimationToggle = (value, fallback = true) => {
+			if (value === undefined || value === null || value === '') {
+				return fallback;
+			}
+			if (value === true || value === 1) {
+				return true;
+			}
+			if (value === false || value === 0) {
+				return false;
+			}
+			const normalized = String(value).trim().toLowerCase();
+			if (['1', 'true', 'yes', 'on'].includes(normalized)) {
+				return true;
+			}
+			if (['0', 'false', 'no', 'off'].includes(normalized)) {
+				return false;
+			}
+			return fallback;
+		};
 
 		const applyVisualControlsToBusinessView = () => {
 			const settings = collectControlSettings();
@@ -431,9 +450,13 @@ const Tp3App = {
 			const startTourTimers = () => {
 				clearTourTimers();
 
+				const animationModule = window.businessviewJson?.details?.modules?.panoAnimation || {};
+				const jumpsEnabled = toAnimationToggle(animationModule.jumps, true);
+				const rotationEnabled = toAnimationToggle(animationModule.rotation, true);
+
 				const rotationFactor = Number(this.AnmationOptions.panoRotationFactor) || 0;
 				const rotationTimer = Math.max(1, Number(this.AnmationOptions.panoRotationTimer) || 0);
-				if (rotationFactor !== 0 && rotationTimer > 0) {
+				if (rotationEnabled && rotationFactor !== 0 && rotationTimer > 0) {
 					let lastHeading = null;
 					this._panoRotationIntervalId = window.setInterval(() => {
 						if (!this.panorama) {
@@ -458,7 +481,7 @@ const Tp3App = {
 
 			const jumpTimer = Math.max(1, Number(this.AnmationOptions.panoJumpTimer) || 0);
 			const panoButtons = getCurrentBusinessViewPanoButtons();
-			if (jumpTimer > 0 && panoButtons.length > 1) {
+			if (jumpsEnabled && jumpTimer > 0 && panoButtons.length > 1) {
 				this._panoJumpIntervalId = window.setInterval(() => {
 					const buttons = getCurrentBusinessViewPanoButtons();
 					if (buttons.length < 2) {
@@ -727,6 +750,7 @@ const Tp3App = {
 				}
 
 				Tp3App.initPano(data);
+				syncAnimationOptionsFromControls();
 				startTourTimers();
 				this.updateStatus(type === 'pano' ? 'Panorama geladen.' : 'BusinessView geladen.', 'secondary');
 			} catch (error) {


### PR DESCRIPTION
### Motivation
- Ensure pano animation behavior (`jumps` and `rotation`) follows the module-level toggles instead of always running.
- Keep user-configured animation settings (`panoJumpTimer`, `panoRotationTimer`, `panoRotationFactor`, `panoJumpsRandom`) active when switching from one panorama to the next.

### Description
- Added a helper `toAnimationToggle` to robustly parse boolean-like toggle values from module settings.
- Read `window.businessviewJson.details.modules.panoAnimation` and gate starting of rotation and jump timers using `rotationEnabled` and `jumpsEnabled` flags.
- Call `syncAnimationOptionsFromControls()` after `Tp3App.initPano(data)` to re-sync jump/rotation settings from the controls when a pano is loaded.
- Start/clear timers via the existing `startTourTimers()` / `clearTourTimers()` logic so rotation/jump intervals respect toggles and updated values.

### Testing
- Ran `node --check Resources/Public/JavaScript/Tp3App.js`, which completed with no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0ef19c8c883258148663f3ade9cc8)